### PR TITLE
CI: Fixes for Go 1.13

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -20,3 +20,4 @@ linters:
     - gocritic
     - gochecknoinits
     - gochecknoglobals
+    - typecheck # Go 1.13 incompatible pending new golangci-lint binary release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: go
 go:
   - "stable"
-env:
-  - GO111MODULE=on
 
 # Override the base install phase so that the project can be installed using
 # `-mod=vendor` to use vendored dependencies
 install:
   # Install `golangci-lint` using their installer script
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
   # Install `cover` and `goveralls` without `GO111MODULE` enabled so that we
   # don't download project dependencies and just put the tools in $GOPATH/bin
   - GO111MODULE=off go get golang.org/x/tools/cmd/cover
@@ -18,9 +16,6 @@ install:
   - go install -mod=vendor -v -race ./...
 
 script:
-  # Download module deps - this _shouldn't_ be required but without it `golangci-lint` seems to fail in Travis.
-  # TODO(@cpu): Figure out a way to remove this hacky workaround to speed up CI.
-  - go mod download
   # Vet Go source code using the linter config (see .golang-ci.yml)
   - golangci-lint run
   # Run project unit tests (with the race detector enabled and atomic coverage

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/letsencrypt/gorepotemplate
+
+go 1.13


### PR DESCRIPTION
* To fix the repo for Go 1.13 I had to disable the `typecheck` lint. It fails when run on Go 1.13 code because the binary `golangci-lint` install we use was built with Go 1.12. Rather than switch to building it from src we can temporarily disable the `typecheck` lint until there is a new binary `golang-ci` release to adopt.
* Added a `go.mod` to this repo.
* Upgraded to the latest available `golangci-lint` release (`1.17.1`) and removed the unnecessary `go mod download` workaround from before.