### PR TITLE
Various CI/linting updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,15 +11,15 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.18
+        go-version: 1.23
 
     - name: Build
       run: go build -v ./...
@@ -28,7 +28,6 @@ jobs:
       run: go test -v ./...
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.45.2
-        only-new-issues: true
+        version: v1.61

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,12 +12,13 @@ linters:
     - stylecheck
     - gosec
     - dupl
-    - maligned
     - depguard
     - lll
     - prealloc
-    - scopelint
     - gocritic
     - gochecknoinits
     - gochecknoglobals
-    - typecheck # Go 1.13 incompatible pending new golangci-lint binary release
+    # These are deprecated
+    - execinquery
+    - exportloopref
+    - gomnd

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,6 +18,10 @@ linters:
     - gocritic
     - gochecknoinits
     - gochecknoglobals
+    - exhaustruct
+    - testpackage
+    - paralleltest
+    - nlreturn
     # These are deprecated
     - execinquery
     - exportloopref

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,6 +22,7 @@ linters:
     - testpackage
     - paralleltest
     - nlreturn
+    - perfsprint
     # These are deprecated
     - execinquery
     - exportloopref

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/letsencrypt/gorepotemplate
 
-go 1.18
+go 1.23

--- a/hello.go
+++ b/hello.go
@@ -14,5 +14,6 @@ func Hello(name string) string {
 	if name == "" {
 		return "Hello"
 	}
+
 	return fmt.Sprintf("Hello %s", strings.ToLower(name))
 }


### PR DESCRIPTION
- Upgrade to Go 1.23
- Pin specific software versions in CI:
  - Ubuntu: `24.04`
  - Go: `1.23`
- Update golangci-lint options:
  - Update version to latest minor release, which is `v1.60`
  - Disable `only-new-issues`, because it can cause linter issues to get missed. Really, we should require all changes to be in full compliance with lints. If the `main` branch is in full compliance, then the only issues that should show up on PRs will be the ones added in that change anyways.
- Change list of excluded linters:
  - Add deprecated linters that will be removed in a future release of golangci-lint:
    - `execinquery`
    - `exportloopref`
    - `gomnd`
  - Remove linters that have already been removed from golangci-lint:
    - `maligned`
    - `scopelint`
    - `typecheck`